### PR TITLE
For restart purposes, treat bootClear like bootAlarm

### DIFF
--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -29,7 +29,7 @@
 
 namespace NetSender {
 
-#define VERSION                172
+#define VERSION                173
 
 #define WIFI_SIZE              80
 #define DKEY_SIZE              20


### PR DESCRIPTION
This avoids unnecessary EEPROM re-writes.