### PR TITLE
SetMode and SetError no longer take the varsum param

### DIFF
--- a/pi/cmd/test-netsender/main.go
+++ b/pi/cmd/test-netsender/main.go
@@ -148,7 +148,7 @@ func burst(ns *netsender.Sender, burstPeriod int) {
 
 	mu.Lock()
 	tl.Log(netsender.InfoLevel, "Bursting done. Resetting mode to Normal.")
-	ns.SetMode("Normal", &varsum)
+	ns.SetMode("Normal")
 	bursting = false
 	mu.Unlock()
 }

--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -947,7 +947,7 @@ func (ns *Sender) Mode() string {
 }
 
 // SetMode sets the client mode, resets the client's varsum and forces a sync.
-func (ns *Sender) SetMode(mode string, vs *int) {
+func (ns *Sender) SetMode(mode string) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
 	if mode == ns.mode {
@@ -955,7 +955,7 @@ func (ns *Sender) SetMode(mode string, vs *int) {
 	}
 	ns.mode = mode
 	ns.sync = true
-	*vs = 0
+	ns.varSum = -1
 }
 
 // Error gets the client error value.
@@ -967,7 +967,7 @@ func (ns *Sender) Error() string {
 }
 
 // SetError sets the client error, resets the client's varsum and forces a sync.
-func (ns *Sender) SetError(error string, vs *int) {
+func (ns *Sender) SetError(error string) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
 	if error == ns.error {
@@ -975,7 +975,7 @@ func (ns *Sender) SetError(error string, vs *int) {
 	}
 	ns.error = error
 	ns.sync = true
-	*vs = 0
+	ns.varSum = -1
 }
 
 // Upgrade performs an upgrade of code to tag using the Sender.upgrader function

--- a/pi/netsender/netsender_test.go
+++ b/pi/netsender/netsender_test.go
@@ -34,7 +34,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"testing/clientest"
+	"testing/iotest"
 	"time"
 )
 
@@ -263,7 +263,7 @@ func TestJSONDecoder(t *testing.T) {
 }
 
 const (
-	testConfig          = "ma 00:00:00:00:00:01\ndk 10000001\nsh data.cloudblue.org\n" // contents of the netsender.conf used for testing.
+	testConfig = "ma 00:00:00:00:00:01\ndk 10000001\nsh data.cloudblue.org\n" // contents of the netsender.conf used for testing.
 )
 
 // TestSync tests synchronization of client mode and error values with NetReceiver.
@@ -281,20 +281,14 @@ func TestSync(t *testing.T) {
 		t.Errorf("netsender.New failed with error %v", err)
 	}
 
-	// Check our mode is Normal to begin with.
-	_, err = ns.Vars()
-	if err != nil {
-		t.Errorf("ns.Vars failed with error %v", err)
-	}
-	if ns.Mode() != "Normal" {
-		t.Errorf("Expected Normal for ns.Mode(), got %s", ns.Mode())
-	}
+	// Reset mode and error.
+	ns.setModeAndError(t, "Normal", "")
 
 	// Set our mode & error to Paused and TestError respectively.
-	ns.setModeAndEror(t, "Paused", "TestError")
+	ns.setModeAndError(t, "Paused", "TestError")
 
-	// Now reset our mode & error for next time.
-	ns.setModeAndEror(t, "Normal", "")
+	// Reset our mode and error
+	ns.setModeAndError(t, "Normal", "")
 }
 
 // TestTimeout tests timeout.
@@ -346,13 +340,13 @@ func createNetsenderConfig() (name string, err error) {
 	return name, nil
 }
 
-// setModeAndEror sets the mode and error and then tests that the values are as expected.
-func (ns *Sender) setModeAndEror(t *testing.T, mode, error string) {
+// setModeAndError sets the mode and error and then tests that the values are as expected.
+func (ns *Sender) setModeAndError(t *testing.T, mode, error string) {
+	ns.SetMode(mode)
+	ns.SetError(error)
 	vs := ns.VarSum()
-	ns.SetMode(mode, &vs)
-	ns.SetError(error, &vs)
-	if vs != 0 {
-		t.Errorf("Expected 0 for vs, got %d", vs)
+	if vs != -1 {
+		t.Errorf("Expected -1 for vs, got %d", vs)
 	}
 	vars, err := ns.Vars()
 	if err != nil {


### PR DESCRIPTION
An overdue simplification to the NetSender API.
Setting the sender's varSum to -1 is sufficient to force a resend of vars.