### PR TITLE
Upgrader improvements

### DIFF
--- a/pi/cmd/test-netsender/main.go
+++ b/pi/cmd/test-netsender/main.go
@@ -148,7 +148,7 @@ func burst(ns *netsender.Sender, burstPeriod int) {
 
 	mu.Lock()
 	tl.Log(netsender.InfoLevel, "Bursting done. Resetting mode to Normal.")
-	ns.SetMode("Normal", &varsum)
+	ns.SetMode("Normal")
 	bursting = false
 	mu.Unlock()
 }

--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -155,10 +155,10 @@ const (
 	debugSetLogLevel      = "set log level"
 )
 
-// NetSender error identifiers.
-// NB: These are prefixed 'er' rather than 'err' to avoid confusion with Go errors
+// NetSender modes and errors.
 const (
-	erUpgrade = "upgradeError"
+	modeCompleted = "Completed"
+	errorUpgrade  = "upgradeError"
 )
 
 var errNoKey = errors.New("key not found in JSON")
@@ -442,7 +442,7 @@ func (ns *Sender) Run() error {
 
 	case ResponseUpgrade:
 		ns.logger.Log(InfoLevel, infoUpgradeRequest)
-		if ns.Mode() == "Completed" {
+		if ns.Mode() == modeCompleted {
 			return nil // Nothing to do.
 		}
 		if ns.IsUpgrading() {
@@ -986,7 +986,7 @@ func (ns *Sender) SetError(error string) {
 
 // Upgrade performs an upgrade of the device software for the
 // configured client type (ct) and client version (cv). Sets the mode
-// to "Completed" upon completion, successful or otherwise. Sets the
+// to modeCompleted upon completion, successful or otherwise. Sets the
 // error to errUpgrade if the upgrade fails.
 func (ns *Sender) Upgrade() {
 	ct := strings.ToLower(ns.Param("ct"))
@@ -1013,12 +1013,12 @@ func (ns *Sender) Upgrade() {
 
 	if err != nil {
 		ns.logger.Log(WarningLevel, warnUpgraderError, "upgrader", ns.upgrader, "ct", ct, "cv", cv)
-		ns.SetError(erUpgrade)
+		ns.SetError(errorUpgrade)
 	} else {
 		ns.logger.Log(InfoLevel, infoUpgraded, "upgrader", ns.upgrader, "ct", ct, "cv", cv)
 	}
 
-	ns.SetMode("Completed")
+	ns.SetMode(modeCompleted)
 	ns.Config()
 }
 

--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -947,7 +947,7 @@ func (ns *Sender) Mode() string {
 }
 
 // SetMode sets the client mode, resets the client's varsum and forces a sync.
-func (ns *Sender) SetMode(mode string, vs *int) {
+func (ns *Sender) SetMode(mode string) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
 	if mode == ns.mode {
@@ -955,7 +955,7 @@ func (ns *Sender) SetMode(mode string, vs *int) {
 	}
 	ns.mode = mode
 	ns.sync = true
-	*vs = 0
+	ns.varSum = -1
 }
 
 // Error gets the client error value.
@@ -967,7 +967,7 @@ func (ns *Sender) Error() string {
 }
 
 // SetError sets the client error, resets the client's varsum and forces a sync.
-func (ns *Sender) SetError(error string, vs *int) {
+func (ns *Sender) SetError(error string) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
 	if error == ns.error {
@@ -975,7 +975,7 @@ func (ns *Sender) SetError(error string, vs *int) {
 	}
 	ns.error = error
 	ns.sync = true
-	*vs = 0
+	ns.varSum = -1
 }
 
 // Upgrade performs an upgrade of code to tag using the Sender.upgrader function

--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -987,7 +987,7 @@ func (ns *Sender) SetError(error string) {
 // Upgrade performs an upgrade of the device software for the
 // configured client type (ct) and client version (cv). Sets the mode
 // to modeCompleted upon completion, successful or otherwise. Sets the
-// error to errUpgrade if the upgrade fails.
+// error to errorUpgrade if the upgrade fails.
 func (ns *Sender) Upgrade() {
 	ct := strings.ToLower(ns.Param("ct"))
 	if ct == "" {

--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -39,7 +39,6 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
-	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -127,6 +126,7 @@ const (
 	warnHttpResponse      = "error in response"
 	warnSetLogLevel       = "unsupported log level"
 	warnRebootError       = "error rebooting"
+	warnMissingDeviceType = "device type required for upgrade"
 	warnUpgraderNotFound  = "upgrader not found"
 	warnUpgraderError     = "error executing upgrader"
 	warnUpgradeFailed     = "upgrade failed"
@@ -137,13 +137,12 @@ const (
 	infoRebootRequest     = "received reboot request"
 	infoDebugRequest      = "received debug request"
 	infoUpgradeRequest    = "received upgrade request"
-	infoUpgradeCancelled  = "upgrade cancelled"
+	infoTestRequest       = "received test request"
+	infoShutdownRequest   = "received shutdown request"
 	infoRebooting         = "rebooting"
 	infoStackTrace        = "stack trace"
 	infoReceivedVars      = "received vars"
 	infoUpdateRequired    = "update required"
-	infoUpgradedAlready   = "already upgraded"
-	infoUpgradeStarting   = "upgrade starting"
 	infoUpgrading         = "upgrade in progress"
 	infoUpgraded          = "completed upgrade"
 	debugRunning          = "running"
@@ -156,12 +155,17 @@ const (
 	debugSetLogLevel      = "set log level"
 )
 
+// NetSender error identifiers.
+// NB: These are prefixed 'er' rather than 'err' to avoid confusion with Go errors
+const (
+	erUpgrade = "upgradeError"
+)
+
 var errNoKey = errors.New("key not found in JSON")
 
 // Sender represents state for a NetSender client.
 type Sender struct {
-	logger Logger // Our logger.
-
+	logger     Logger            // Our logger.
 	mu         sync.Mutex        // Protects our state.
 	configFile string            // Path to config file.
 	config     map[string]string // Our latest configuration.
@@ -171,15 +175,14 @@ type Sender struct {
 	mode       string            // Client mode.
 	error      string            // Client error string, if any.
 	sync       bool              // True if we need to sync client mode or error with the service, false otherwise.
-
-	init       PinInit                              // Pin initialization function, or nil.
-	read       PinReadWrite                         // Pin read function, or nil.
-	write      PinReadWrite                         // Pin write function, or nil.
-	upgradeCmd *exec.Cmd                            // Upgrade command, or nil if no upgrade is in progress.
-	configPins []Pin                                // Pins sent in the /config request.
-	upgrader   func(tag, user, gopath string) error // Upgrader function called for repo upgrade.
-
-	upload, download int // Will hold upload and download speeds in bps.
+	init       PinInit           // Pin initialization function, or nil.
+	read       PinReadWrite      // Pin read function, or nil.
+	write      PinReadWrite      // Pin write function, or nil.
+	configPins []Pin             // Pins sent in the config request.
+	upgrader   string            // Upgrader command.
+	upgrading  bool              // True if upgrading, false otherwise.
+	upload     int               // Measured upload speed in bits per second (in test mode).
+	download   int               // Measured download speed in bits per second (in test mode).
 }
 
 // PinInit defines a pin initialization function, which takes a Pin and arbitrary intialization data.
@@ -195,11 +198,9 @@ type PinReadWrite func(pin *Pin) error
 // local consts
 const (
 	pkgName         = "netsender"
-	version         = 170
+	version         = 171
 	defaultService  = "data.cloudblue.org"
 	monPeriod       = 60
-	tagsFile        = "/var/netsender/tags.conf"
-	upgrader        = "upgrade.sh"
 	rebooter        = "syncreboot"
 	defaultLogLevel = WarningLevel
 	stackTraceSize  = 1 << 16
@@ -214,9 +215,10 @@ func (e *ServerError) Error() string {
 	return e.er
 }
 
-// defaultConfigFile is the default path to the netsender config file.
-// This can be changed using the WithConfigFile option function.
-const defaultConfigFile = "/etc/netsender.conf"
+const (
+	defaultConfigFile = "/etc/netsender.conf" // Default config file. Customize with WithConfigFile.
+	defaultUpgrader   = "pkg-upgrade.sh"      // Default upgrade script. Customize with WithUpgrader
+)
 
 // Timeout is the timeout used for network calls.
 var Timeout = 20 * time.Second
@@ -261,6 +263,7 @@ func New(logger Logger, init PinInit, read, write PinReadWrite, options ...Optio
 func (ns *Sender) Init(logger Logger, init PinInit, read, write PinReadWrite, options ...Option) error {
 	ns.logger = logger
 	ns.configFile = defaultConfigFile
+	ns.upgrader = defaultUpgrader
 	// Set download upload speeds to -1 to indicate they have not been deduced yet.
 	ns.upload, ns.download = -1, -1
 	ns.init, ns.read, ns.write = init, read, write
@@ -399,10 +402,6 @@ func (ns *Sender) Run() error {
 	switch rc {
 	case ResponseUpdate:
 		ns.logger.Log(InfoLevel, infoUpdateRequest)
-		if ns.upgradeCmd != nil {
-			ns.upgradeCmd = nil
-			ns.logger.Log(InfoLevel, infoUpgradeCancelled)
-		}
 		_, err = ns.Config()
 		return err
 
@@ -420,7 +419,7 @@ func (ns *Sender) Run() error {
 		}
 
 	case ResponseShutdown:
-		ns.logger.Log(InfoLevel, "got shutdown request")
+		ns.logger.Log(InfoLevel, infoShutdownRequest)
 		if !ns.IsConfigured() {
 			ns.logger.Log(DebugLevel, "need to config for shutdown request")
 			_, err := ns.Config()
@@ -443,18 +442,19 @@ func (ns *Sender) Run() error {
 
 	case ResponseUpgrade:
 		ns.logger.Log(InfoLevel, infoUpgradeRequest)
-		err = ns.Upgrade(ns.Param("cv"))
-		if err != nil {
-			return fmt.Errorf("could not upgrade: %w", err)
+		if ns.Mode() == "Completed" {
+			return nil // Nothing to do.
+		}
+		if ns.IsUpgrading() {
+			ns.logger.Log(InfoLevel, infoUpgrading)
+			return nil
 		}
 
-		_, err = ns.Config()
-		if err != nil {
-			return fmt.Errorf("could not get configuration information: %w", err)
-		}
+		// Perform the upgrade concurrently.
+		go ns.Upgrade()
 
 	case ResponseTest:
-		ns.logger.Log(InfoLevel, "net test requested")
+		ns.logger.Log(InfoLevel, infoTestRequest)
 		err := ns.TestDownload()
 		if err != nil {
 			return fmt.Errorf("could not test download speed: %w", err)
@@ -571,23 +571,22 @@ func (ns *Sender) Send(requestType int, pins []Pin, opts ...SendOption) (reply s
 	rc = ResponseNone
 
 	switch requestType {
-	case RequestPoll, RequestMts, RequestAct, RequestConfig:
+	case RequestPoll, RequestMts, RequestAct, RequestConfig, RequestVars:
 		path = fmt.Sprintf("/%s?vn=%d&ma=%s&dk=%s&ut=%d", requestTypes[requestType], version, ns.Param("ma"), ns.Param("dk"), uptime)
-
-	case RequestVars:
-		// Send the mode and error if we need to sync our client's values with the service's.
-		ns.mu.Lock()
-		sync := ns.sync
-		ns.mu.Unlock()
-		if sync {
-			path = fmt.Sprintf("/vars?vn=%d&ma=%s&dk=%s&md=%s&er=%s&ut=%d", version, ns.Param("ma"), ns.Param("dk"), ns.Mode(), ns.Error(), uptime)
-		} else {
-			path = fmt.Sprintf("/vars?vn=%d&ma=%s&dk=%s&ut=%d", version, ns.Param("ma"), ns.Param("dk"), uptime)
-		}
 
 	default:
 		return reply, rc, errors.New("Invalid request type: " + strconv.Itoa(requestType))
 	}
+
+	ns.mu.Lock()
+	if ns.sync {
+		// Sync the mode and (optionally) error with the service.
+		path += "&md=" + ns.mode
+		if ns.error != "" {
+			path += "&er=" + ns.error
+		}
+	}
+	ns.mu.Unlock()
 
 	// Append pin parameters to URL path.
 	for _, pin := range pins {
@@ -842,6 +841,13 @@ func (ns *Sender) IsConfigured() bool {
 	return ns.configured
 }
 
+// IsUpgrading returns true if an upgrade is is progress.
+func (ns *Sender) IsUpgrading() bool {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	return ns.upgrading
+}
+
 // Param returns a single config parameter value.
 func (ns *Sender) Param(param string) string {
 	ns.mu.Lock()
@@ -978,72 +984,42 @@ func (ns *Sender) SetError(error string) {
 	ns.varSum = -1
 }
 
-// Upgrade performs an upgrade of code to tag using the Sender.upgrader function
-// that is specified using the WithUpgrader option (see netsender/options.go).
-// The upgrader function specifies the actions that need to occur for the upgrade
-// to the provided tag. This would likely be a sequence of exec.Commands using git
-// to pull the new tag and perform any build instructions i.e. make commands.
-func (ns *Sender) Upgrade(tag string) error {
-	ns.logger.Log(DebugLevel, "upgrading")
-	if ns.upgrader == nil {
-		return errors.New("upgrader function has not been provided")
+// Upgrade performs an upgrade of the device software for the
+// configured client type (ct) and client version (cv). Sets the mode
+// to "Completed" upon completion, successful or otherwise. Sets the
+// error to errUpgrade if the upgrade fails.
+func (ns *Sender) Upgrade() {
+	ct := strings.ToLower(ns.Param("ct"))
+	if ct == "" {
+		ns.logger.Log(WarningLevel, warnMissingDeviceType)
+		return
+	}
+	cv := strings.ToLower(ns.Param("cv"))
+	if cv == "" {
+		cv = "@latest"
 	}
 
-	if tag == "" {
-		return errors.New("Empty tag")
-	}
+	ns.mu.Lock()
+	ns.upgrading = true
+	ns.mu.Unlock()
 
-	found, err := confHasTag(tag)
+	ns.logger.Log(InfoLevel, "upgrading", "upgrader", ns.upgrader, "ct", ct, "cv", cv)
+	cmd := exec.Command(ns.upgrader, ct, cv)
+	err := cmd.Run()
+
+	ns.mu.Lock()
+	ns.upgrading = false
+	ns.mu.Unlock()
+
 	if err != nil {
-		return fmt.Errorf("could not check for tag in tags.conf file: %w", err)
-	}
-	if found {
-		ns.logger.Log(InfoLevel, infoUpgradedAlready, "tag", tag)
-		return nil
-	}
-
-	// This will be recreated after upgrade success.
-	err = os.Remove(tagsFile)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("could not remove tags file: %w", err)
+		ns.logger.Log(WarningLevel, warnUpgraderError, "upgrader", ns.upgrader, "ct", ct, "cv", cv)
+		ns.SetError(erUpgrade)
+	} else {
+		ns.logger.Log(InfoLevel, infoUpgraded, "upgrader", ns.upgrader, "ct", ct, "cv", cv)
 	}
 
-	// Find the user of the GOPATH.
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		return errors.New("gopath is undefined")
-	}
-
-	// Get the user from the gopath.
-	split := strings.Split(gopath, "/")
-	if len(split) == 1 || len(split) == 0 {
-		return errors.New("could not split gopath")
-	}
-	user := split[2]
-
-	err = ns.upgrader(tag, user, gopath)
-	if err != nil {
-		return fmt.Errorf("could not perform upgrade: %w", err)
-	}
-
-	err = os.WriteFile(tagsFile, []byte(tag), 0644)
-	if err != nil {
-		return fmt.Errorf("could not write new tags file: %w", err)
-	}
-
-	return nil
-}
-
-// confHasTag checks for the presence of a tag in tags.conf
-func confHasTag(tag string) (bool, error) {
-	tags, err := os.ReadFile(tagsFile)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return sliceutils.ContainsString(strings.Split(string(tags), "\n"), tag), nil
+	ns.SetMode("Completed")
+	ns.Config()
 }
 
 // writeConfig writes configuration info to configFile in configParams order.

--- a/pi/netsender/netsender_test.go
+++ b/pi/netsender/netsender_test.go
@@ -34,7 +34,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"testing/clientest"
+	"testing/iotest"
 	"time"
 )
 
@@ -263,7 +263,7 @@ func TestJSONDecoder(t *testing.T) {
 }
 
 const (
-	testConfig          = "ma 00:00:00:00:00:01\ndk 10000001\nsh data.cloudblue.org\n" // contents of the netsender.conf used for testing.
+	testConfig = "ma 00:00:00:00:00:01\ndk 10000001\nsh data.cloudblue.org\n" // contents of the netsender.conf used for testing.
 )
 
 // TestSync tests synchronization of client mode and error values with NetReceiver.
@@ -281,20 +281,14 @@ func TestSync(t *testing.T) {
 		t.Errorf("netsender.New failed with error %v", err)
 	}
 
-	// Check our mode is Normal to begin with.
-	_, err = ns.Vars()
-	if err != nil {
-		t.Errorf("ns.Vars failed with error %v", err)
-	}
-	if ns.Mode() != "Normal" {
-		t.Errorf("Expected Normal for ns.Mode(), got %s", ns.Mode())
-	}
+	// Reset mode and error.
+	ns.setModeAndError(t, "Normal", "")
 
 	// Set our mode & error to Paused and TestError respectively.
-	ns.setModeAndEror(t, "Paused", "TestError")
+	ns.setModeAndError(t, "Paused", "TestError")
 
-	// Now reset our mode & error for next time.
-	ns.setModeAndEror(t, "Normal", "")
+	// Reset our mode and error
+	ns.setModeAndError(t, "Normal", "")
 }
 
 // TestTimeout tests timeout.
@@ -346,13 +340,13 @@ func createNetsenderConfig() (name string, err error) {
 	return name, nil
 }
 
-// setModeAndEror sets the mode and error and then tests that the values are as expected.
-func (ns *Sender) setModeAndEror(t *testing.T, mode, error string) {
+// setModeAndError sets the mode and error and then tests that the values are as expected.
+func (ns *Sender) setModeAndError(t *testing.T, mode, error string) {
+	ns.SetMode(mode)
+	ns.SetError(error)
 	vs := ns.VarSum()
-	ns.SetMode(mode, &vs)
-	ns.SetError(error, &vs)
-	if vs != 0 {
-		t.Errorf("Expected 0 for vs, got %d", vs)
+	if vs != -1 {
+		t.Errorf("Expected -1 for vs, got %d", vs)
 	}
 	vars, err := ns.Vars()
 	if err != nil {

--- a/pi/netsender/options.go
+++ b/pi/netsender/options.go
@@ -92,9 +92,9 @@ func WithConfigFile(f string) Option {
 	}
 }
 
-// WithUpgrader returns an option that sets the upgrader function which is called
-// when netsender.Sender.Upgrade() is called.
-func WithUpgrader(u func(tag, user, gopath string) error) Option {
+// WithUpgrader returns an option that sets the upgrader script which is called
+// when an upgrade request is received.
+func WithUpgrader(u string) Option {
 	return func(s *Sender) error {
 		s.upgrader = u
 		return nil


### PR DESCRIPTION
Refactored upgrade mechanism to utilize upgrade scripts that take client type (ct) and version (cv).
The` NetSender.Upgrade` method is just a wrapper, with all of the upgrade logic performed by a script, which is configurable via the `WithUpgrader` option.