### PR TITLE
Pi: Parse int with 64 bitsize

### DIFF
--- a/pi/netsender/netsender.go
+++ b/pi/netsender/netsender.go
@@ -198,7 +198,7 @@ type PinReadWrite func(pin *Pin) error
 // local consts
 const (
 	pkgName         = "netsender"
-	version         = 171
+	version         = 172
 	defaultService  = "data.cloudblue.org"
 	monPeriod       = 60
 	rebooter        = "syncreboot"
@@ -1057,7 +1057,7 @@ func (s *Sender) readConfig() (map[string]string, error) {
 			continue
 		}
 		if sliceutils.ContainsString(configNumbers, name) {
-			if _, err := strconv.Atoi(val); err != nil {
+			if _, err := strconv.ParseInt(val, 10, 64); err != nil {
 				return nil, errors.New("Expected int for config param: " + name)
 			}
 		}


### PR DESCRIPTION
Since device keys are now up to 6 digits long, we need to be able to parse 64bit integers. strconv.Atoi() defaults to 32bits on a 32bit system.