### PR TITLE
Added support for mode variable

### DIFF
--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -1018,10 +1018,10 @@ bool getVars(int vars[MAX_VARS], bool* changed) {
   if (!request(RequestVars, NULL, NULL, &reconfig, reply) || extractJson(reply, "er", param)) {
     return false;
   }
-  bool hasId = extractJson(reply, "id", id);
+  auto hasId = extractJson(reply, "id", id);
   if (hasId) log(logDebug, "id=%s", id.c_str());
 
-  bool hasMode = extractJson(reply, "mode", mode);
+  auto hasMode = extractJson(reply, "mode", mode);
   if (hasMode) {
     log(logDebug, "mode=%s", mode.c_str());
     Mode = mode;

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -1269,7 +1269,7 @@ bool run(int* varsum) {
         Mode = mode::LowVoltageAlarm;
         log(logDebug, "mode=%s", Mode);
         // Notfiy the service that we're alarmed.
-        if (!(wifiBegin() && request(RequestPoll, NULL, NULL, &reconfig, reply))) {
+        if (!(wifiBegin() && request(RequestVars, NULL, NULL, &reconfig, reply))) {
           log(logWarning, "Failed to notify service of low voltage alarm");
 	}
         cyclePin(STATUS_PIN, statusVoltageAlarm);

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -210,6 +210,11 @@ typedef enum logLevel {
 
 const char* logLevels[] = {"", "Error", "Warning", "Info", "Debug"};
 
+namespace mode {
+  constexpr const char* Normal = "Normal";
+  constexpr const char* LowVoltageAlarm = "LowVoltageAlarm";
+}
+
 // Exported globals.
 Configuration Config;
 ReaderFunc ExternalReader = NULL;
@@ -225,7 +230,7 @@ static unsigned long Time = 0;
 static unsigned long AlarmedTime = 0;
 static int NetworkFailures = 0;
 static int SimulatedBat = 0;
-static String Mode = "Normal";
+static String Mode = mode::Normal;
 
 // Forward declarations.
 void restart(bootReason, bool);
@@ -1002,7 +1007,7 @@ bool config() {
     cyclePin(STATUS_PIN, statusConfigUpdate);
   }
   Configured = true;
-  Mode = "Normal";
+  Mode = mode::Normal;
   return true;
 }
 
@@ -1254,7 +1259,7 @@ bool run(int* varsum) {
       if (!XPin[xAlarmed]) {
         // low voltage; raise the alarm and turn off WiFi!
         log(logWarning, "Low voltage alarm!");
-        Mode = "LowVoltageAlarm";
+        Mode = mode::LowVoltageAlarm;
         // Notfiy the service that we're alarmed.
         if (wifiBegin()) {
 	  bool reconfig;
@@ -1275,7 +1280,7 @@ bool run(int* varsum) {
         return pause(false, pulsed, &lag);
       }
       log(logInfo, "Low voltage alarm cleared");
-      Mode = "Normal";
+      Mode = mode::Normal;
       writeAlarm(false, true);
     }
     if (XPin[xBat] > Config.vars[pvPeakVoltage]) {

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -1335,7 +1335,7 @@ bool run(int* varsum) {
         // low voltage; raise the alarm and turn off WiFi!
         log(logWarning, "Low voltage alarm!");
         Mode = mode::LowVoltageAlarm;
-        log(logDebug, "mode=%s", Mode);
+        log(logDebug, "mode=%s", Mode.c_str());
         // Notfiy the service that we're alarmed.
         if (!(wifiBegin() && request(RequestConfig, NULL, NULL, &reconfig, reply))) {
           log(logWarning, "Failed to notify service of low voltage alarm");

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -899,10 +899,10 @@ bool request(RequestType req, Pin * inputs, Pin * outputs, bool * reconfig, Stri
             LocalAddress[0], LocalAddress[1], LocalAddress[2], LocalAddress[3], ut, Mode.c_str());
     break;
   case RequestPoll:
-    sprintf(path, "/poll?vn=%d&ma=%s&dk=%s&ut=%ld&md=%s", VERSION, MacAddress, Config.dkey, ut, Mode.c_str());
+    sprintf(path, "/poll?vn=%d&ma=%s&dk=%s&ut=%ld", VERSION, MacAddress, Config.dkey, ut);
     break;
   case RequestAct:
-    sprintf(path, "/act?vn=%d&ma=%s&dk=%s&ut=%ld&md=%s", VERSION, MacAddress, Config.dkey, ut, Mode.c_str());
+    sprintf(path, "/act?vn=%d&ma=%s&dk=%s&ut=%ld", VERSION, MacAddress, Config.dkey, ut);
     break;
   case RequestVars:
     sprintf(path, "/vars?vn=%d&ma=%s&dk=%s&ut=%ld", VERSION, MacAddress, Config.dkey, ut);
@@ -1337,9 +1337,9 @@ bool run(int* varsum) {
         Mode = mode::LowVoltageAlarm;
         log(logDebug, "mode=%s", Mode);
         // Notfiy the service that we're alarmed.
-        if (!(wifiBegin() && request(RequestPoll, NULL, NULL, &reconfig, reply))) {
+        if (!(wifiBegin() && request(RequestConfig, NULL, NULL, &reconfig, reply))) {
           log(logWarning, "Failed to notify service of low voltage alarm");
-	}
+        }
         cyclePin(STATUS_PIN, statusVoltageAlarm);
         writeAlarm(true, true);
         wifiControl(false);

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -1263,16 +1263,11 @@ bool run(int* varsum) {
         log(logWarning, "Low voltage alarm!");
         Mode = mode::LowVoltageAlarm;
         // Notfiy the service that we're alarmed.
-        if (wifiBegin()) {
-	  bool reconfig;
-	  String reply;
-          if (!request(RequestPoll, NULL, NULL, &reconfig, reply)) {
-            log(logWarning, "Failed to notify service of low voltage alarm");
-          }
+        if (!(wifiBegin() && request(RequestPoll, NULL, NULL, &reconfig, reply))) {
+          log(logWarning, "Failed to notify service of low voltage alarm");
 	}
         cyclePin(STATUS_PIN, statusVoltageAlarm);
         writeAlarm(true, true);
-        // Wifi should already be off but just in case.
         wifiControl(false);
       }
       return pause(false, pulsed, &lag);

--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -905,7 +905,7 @@ bool request(RequestType req, Pin * inputs, Pin * outputs, bool * reconfig, Stri
     sprintf(path, "/act?vn=%d&ma=%s&dk=%s&ut=%ld&md=%s", VERSION, MacAddress, Config.dkey, ut, Mode.c_str());
     break;
   case RequestVars:
-    sprintf(path, "/vars?vn=%d&ma=%s&dk=%s&ut=%ld&md=%s", VERSION, MacAddress, Config.dkey, ut, Mode.c_str());
+    sprintf(path, "/vars?vn=%d&ma=%s&dk=%s&ut=%ld", VERSION, MacAddress, Config.dkey, ut);
     break;
   }
 
@@ -1337,7 +1337,7 @@ bool run(int* varsum) {
         Mode = mode::LowVoltageAlarm;
         log(logDebug, "mode=%s", Mode);
         // Notfiy the service that we're alarmed.
-        if (!(wifiBegin() && request(RequestVars, NULL, NULL, &reconfig, reply))) {
+        if (!(wifiBegin() && request(RequestPoll, NULL, NULL, &reconfig, reply))) {
           log(logWarning, "Failed to notify service of low voltage alarm");
 	}
         cyclePin(STATUS_PIN, statusVoltageAlarm);

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -36,7 +36,7 @@ namespace NetSender {
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                210
+#define VERSION                211
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -30,13 +30,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                177
+#define VERSION                178
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                212
+#define VERSION                213
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -30,13 +30,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                175
+#define VERSION                177
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                211
+#define VERSION                212
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64


### PR DESCRIPTION
The mode variable, which is normally "Normal", is set to "LowVoltageAlarm" whenever a low voltage alarm occurs.

The service can also set the `mode` variable which is sent to the client along with the other variables, although the only result is that it will be logged.