### PR TITLE
arduino/netsender: log all levels when unconfigured

### DIFF
--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -231,11 +231,13 @@ void restart(bootReason, bool);
 
 // Utilities:
 
-// log prints a message if the given level is less than or equal to the LogLevel var level.
+// log prints a message if the given level is less than or equal to the LogLevel var level,
+// or if the system is not yet configured.
 void log(LogLevel level, const char* format, ...) {
-  if (level > Config.vars[pvLogLevel] || level < logNone) {
+  if (Configured && (level > Config.vars[pvLogLevel] || level < logNone)) {
     return;
   }
+
   printf("%s: ", logLevels[level]);
   va_list args;
   va_start(args, format);

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -30,13 +30,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                175
+#define VERSION                176
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                210
+#define VERSION                211
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64


### PR DESCRIPTION
This is done so that we can easily see what's going on when the ESP hasn't had a chance to get it's configuration.