### PR TITLE
temp-netsender: Update DHT and SST pin numbers

### DIFF
--- a/arduino/temp-netsender/temp-netsender.ino
+++ b/arduino/temp-netsender/temp-netsender.ino
@@ -49,8 +49,8 @@ LICENSE
 #define DHTPIN       12
 #define DTPIN        13
 #else
-#define DHTPIN       36
-#define DTPIN        39
+#define DHTPIN       14
+#define DTPIN        13
 #endif
 #define ZERO_CELSIUS 273.15 // In Kelvin.
 


### PR DESCRIPTION
This change reflects the new v4 revB controller PCB pin numbering to fix the input only mode issue.