### PR TITLE
arduino/netsender: sync mode with alarm state

### DIFF
--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -30,13 +30,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                178
+#define VERSION                179
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                213
+#define VERSION                214
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64


### PR DESCRIPTION
This was done in the case that the Mode and alarm pin are not aligned. Logging was also added.

It has been tested and this change successfully syncs the mode back to normal when the lowVoltageAlarm mode hasn't been communicated successfully.