### PR TITLE
Get vars upon restart

### DIFF
--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -30,13 +30,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                179
+#define VERSION                180
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                214
+#define VERSION                10015
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64

--- a/pi/netsender/netsender_test.go
+++ b/pi/netsender/netsender_test.go
@@ -348,7 +348,11 @@ func (ns *Sender) setModeAndError(t *testing.T, mode, error string) {
 	if vs != -1 {
 		t.Errorf("Expected -1 for vs, got %d", vs)
 	}
-	vars, err := ns.Vars()
+	_, err := ns.Config() // Send mode and error to the service.
+	if err != nil {
+		t.Errorf("ns.Config failed with error %v", err)
+	}
+	vars, err := ns.Vars() // Get mode and error from the service.
 	if err != nil {
 		t.Errorf("ns.Vars failed with error %v", err)
 	}


### PR DESCRIPTION
Previously, we only got vars after alarm restarts. Now we do it for _all_ restarts.

This makes it possible to change the `mode` upon restart, which is a prerequisite for Issue #57.