### PR TITLE
Request abstraction layer

### DIFF
--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -874,6 +874,11 @@ bool httpRequest(String url, String body, String& reply) {
 }
 
 // Online request handler, i.e., Normal mode.
+// One-time setup.
+bool OnlineHandler::init() {
+  return true;
+}
+
 // Issue a single request, writing polled values to 'inputs' and actuated values to 'outputs'.
 // Config requests (and only config requests) communicate the device mode and error,
 // where the mode corresponds to the active request handler.

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -27,16 +27,18 @@
 #ifndef NetSender_H
 #define NetSender_H
 
+#include "Arduino.h"
+
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                180
+#define VERSION                181
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                10015
+#define VERSION                10016
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64
@@ -46,13 +48,31 @@ namespace NetSender {
 #define PIN_SIZE               4
 #define IO_SIZE                (MAX_PINS * PIN_SIZE)
 #define MAX_VARS               11
+#define MAX_HANDLERS           2
 
+// Device modes.
+namespace mode {
+  constexpr const char* Online = "Normal";
+  constexpr const char* Offline = "Offline";
+}
+
+// Device requests.
 typedef enum {
   RequestConfig = 0,
   RequestPoll   = 1,
   RequestAct    = 2,
   RequestVars   = 3,
 } RequestType;
+
+// Log levels for use with log function.
+typedef enum logLevel {
+  logNone    = 0,
+  logError   = 1,
+  logWarning = 2,
+  logInfo    = 3,
+  logDebug   = 4,
+  logMax     = 5
+} LogLevel;
 
 // Configuration parameters are saved to the first 256 or 384 bytes of EEPROM
 // for the ESP8266 or ESP32 respectively as follows:
@@ -89,11 +109,58 @@ typedef struct {
 // ReaderFunc represents a pin reading function.
 typedef int (*ReaderFunc)(Pin *);
 
+// BaseHandler defines our abstract base handler class.
+class BaseHandler {
+public:
+  virtual const char* name() = 0;
+  virtual bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) = 0;
+  virtual bool connect() = 0;
+  virtual void disconnect() = 0;
+};
+
+// OnlineHandler defines our handler in normal (online) operating mode.
+class OnlineHandler : public BaseHandler {
+public:
+  const char* name() { return mode::Online; }
+  bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) override;
+  bool connect() override;
+  void disconnect() override;
+private:
+  bool connected;
+};
+
+// OfflineHandler defines our handler in offline mode.
+class OfflineHandler : public BaseHandler {
+public:
+  const char* name() override { return mode::Offline; };
+  bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) override;
+  bool connect() override { return false; };
+  void disconnect() override {};
+};
+
+// HandlerManager defines our handler manager.
+class HandlerManager {
+public:
+  HandlerManager();
+  ~HandlerManager();
+
+  bool add(BaseHandler* handler);     // Add a handler.
+  BaseHandler* set(const char* name); // Set the current/active handler and return it.
+  BaseHandler* get();                 // Get the current/active handler.
+  BaseHandler* get(const char* name); // Get a handler by name.
+
+private:
+  BaseHandler* handlers[MAX_HANDLERS];
+  size_t size;
+  size_t current;
+};
+
 // exported globals
 extern Configuration Config;
 extern ReaderFunc ExternalReader;
 extern ReaderFunc BinaryReader;
 extern int VarSum;
+extern HandlerManager Handlers;
 
 // init should be called from setup once.
 // run should be called from loop until it returns true, e.g., 
@@ -102,6 +169,7 @@ extern int VarSum;
 //  }
 extern void init();
 extern bool run(int*);
+extern void log(LogLevel, const char*, ...);
 
 } // end namespace
 #endif

--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -113,6 +113,7 @@ typedef int (*ReaderFunc)(Pin *);
 class BaseHandler {
 public:
   virtual const char* name() = 0;
+  virtual bool init() = 0;
   virtual bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) = 0;
   virtual bool connect() = 0;
   virtual void disconnect() = 0;
@@ -122,6 +123,7 @@ public:
 class OnlineHandler : public BaseHandler {
 public:
   const char* name() { return mode::Online; }
+  bool init() override;
   bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) override;
   bool connect() override;
   void disconnect() override;
@@ -133,6 +135,7 @@ private:
 class OfflineHandler : public BaseHandler {
 public:
   const char* name() override { return mode::Offline; };
+  bool init() override;
   bool request(RequestType req, Pin* inputs, Pin* outputs, bool* reconfig, String& reply) override;
   bool connect() override { return false; };
   void disconnect() override {};

--- a/arduino/netsender/handlers.cpp
+++ b/arduino/netsender/handlers.cpp
@@ -37,13 +37,13 @@ HandlerManager::~HandlerManager() {
   size = 0;
 }
 
-// add adds a handler.
+// add adds a handler and initializes it.
 bool HandlerManager::add(BaseHandler* handler) {
   if (size == MAX_HANDLERS) {
     return false;
   }
   handlers[++size] = handler;
-  return true;
+  return handler->init();
 }
 
 // set sets the current/active handler.

--- a/arduino/netsender/handlers.cpp
+++ b/arduino/netsender/handlers.cpp
@@ -1,0 +1,78 @@
+/*
+  Description:
+    NetSender handler manager.
+
+  License:
+    Copyright (C) 2025 The Australian Ocean Lab (AusOcean).
+
+    This file is part of NetSender. NetSender is free software: you can
+    redistribute it and/or modify it under the terms of the GNU
+    General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    NetSender is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetSender in gpl.txt.  If not, see
+    <http://www.gnu.org/licenses/>.
+*/
+
+#include "NetSender.h"
+
+namespace NetSender {
+
+HandlerManager::HandlerManager() {
+  size = 0;
+  current = 0;
+}
+
+HandlerManager::~HandlerManager() {
+  for (size_t ii; ii < size; ii++) {
+    delete handlers[ii];
+  }
+  size = 0;
+}
+
+// add adds a handler.
+bool HandlerManager::add(BaseHandler* handler) {
+  if (size == MAX_HANDLERS) {
+    return false;
+  }
+  handlers[++size] = handler;
+  return true;
+}
+
+// set sets the current/active handler.
+BaseHandler* HandlerManager::set(const char* name) {
+  for (size_t ii; ii < size; ii++) {
+    if (strcmp(handlers[ii]->name(), name) == 0) {
+      current = ii;
+      return handlers[current];
+    }
+  }
+  return NULL;
+}
+
+// get() gets the current/active handler.
+BaseHandler* HandlerManager::get() {
+  if (current >= size) {
+    return NULL;
+  }
+  return handlers[current];
+}
+
+// get(name) gets the handler with the given name.
+BaseHandler* HandlerManager::get(const char* name) {
+  for (size_t ii; ii < size; ii++) {
+    if (strcmp(handlers[ii]->name(), name) == 0) {
+      return handlers[ii];
+    }
+  }
+  return NULL;
+}
+
+} // end namespace

--- a/arduino/netsender/offline.cpp
+++ b/arduino/netsender/offline.cpp
@@ -1,0 +1,79 @@
+/*
+  Description:
+    NetSender offline request handler.
+
+  License:
+    Copyright (C) 2025 The Australian Ocean Lab (AusOcean).
+
+    This file is part of NetSender. NetSender is free software: you can
+    redistribute it and/or modify it under the terms of the GNU
+    General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    NetSender is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetSender in gpl.txt.  If not, see
+    <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <ctype.h>
+#include <cstdarg>
+#include <cstdio>
+#include "Arduino.h"
+
+#include "NetSender.h"
+
+namespace NetSender {
+
+// Offline request handler.
+// Requests are handled as follows:
+// - Config & Vars: delegated to the online handler, which will fail unless there is network connectivity.
+// - Poll: write data to local storage, which does not require network connectivity.
+// - Act: does nothing.
+bool OfflineHandler::request(RequestType req, Pin * inputs, Pin * outputs, bool * reconfig, String& reply) {
+  switch (req) {
+  case RequestConfig:
+  case RequestVars:
+    {
+      auto h = Handlers.get(mode::Online);
+      if (h == NULL) {
+        return false;
+      }
+      auto ok = h->request(req, NULL, NULL, reconfig, reply);
+      h->disconnect();
+      return ok;
+    }
+  case RequestPoll:
+    break; // Handle below.
+  case RequestAct:
+    return true;
+  default:
+    return false;
+  }
+
+  if (inputs == NULL) {
+    return true; // Nothing to do.
+  }
+
+  for (int ii = 0; ii < MAX_PINS && inputs[ii].name[0] != '\0'; ii++) {
+    if (inputs[ii].value < 0) {
+      // Omit negative scalars.
+      log(logDebug, "Not saving negative value for %s", inputs[ii].name);
+      continue;
+    }
+    // ToDo: Save value to local storage.
+    log(logDebug, "Saving %s=%s", inputs[ii].name, inputs[ii].value);
+  }
+
+  return true;
+}
+
+} // end namespace

--- a/arduino/netsender/offline.cpp
+++ b/arduino/netsender/offline.cpp
@@ -22,11 +22,6 @@
 */
 
 #include <stdlib.h>
-#include <limits.h>
-#include <string.h>
-#include <ctype.h>
-#include <cstdarg>
-#include <cstdio>
 #include "Arduino.h"
 
 #include "NetSender.h"
@@ -34,6 +29,11 @@
 namespace NetSender {
 
 // Offline request handler.
+// One-time setup.
+bool OfflineHandler::init() {
+  return true;
+}
+
 // Requests are handled as follows:
 // - Config & Vars: delegated to the online handler, which will fail unless there is network connectivity.
 // - Poll: write data to local storage, which does not require network connectivity.


### PR DESCRIPTION
This PR implements a new request layer, based on a new `BaseHandler` abstract class.

The existing functionality has been refactored into the `OnlineHandler`.

Further more, there is a new `OfflineHandler`, which is the stub for planned offline functionality.

The `Handler` global points to the current request handler, which is controlled by the `mode `variable.

Further request handlers can be added by simply subclassing `BaseHandler`.