### PR TITLE
Netsender: Add Offline mode Feature flag

### DIFF
--- a/arduino/netsender/NetSender.cpp
+++ b/arduino/netsender/NetSender.cpp
@@ -27,6 +27,7 @@
 #include <ctype.h>
 #include <cstdarg>
 #include <cstdio>
+#include "config.h"
 
 #if defined ESP8266 || defined ESP32
 #include <EEPROM.h>
@@ -863,7 +864,9 @@ void init(void) {
 
   // Add handlers and set active handler.
   Handlers.add(new OnlineHandler);
+  #ifdef FEATURE_OFFLINE
   Handlers.add(new OfflineHandler);
+  #endif
 
   // Get mode from ESP's non-volatile storage (read-only), or default to online mode.
   if (Prefs.begin(pref::NameSpace, true)) {

--- a/arduino/netsender/config.h
+++ b/arduino/netsender/config.h
@@ -1,0 +1,26 @@
+/*
+  Description:
+    netsender compilation configuration parameters.
+
+  License:
+    Copyright (C) 2025 The Australian Ocean Lab (AusOcean).
+
+    This file is part of NetSender. NetSender is free software: you can
+    redistribute it and/or modify it under the terms of the GNU
+    General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    NetSender is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetSender in gpl.txt.  If not, see
+    <http://www.gnu.org/licenses/>.
+*/
+
+// FEATURE_OFFLINE is a feature flag used to enable building of the offline
+// features of netsender.
+// #define FEATURE_OFFLINE

--- a/arduino/temp-netsender/config.h
+++ b/arduino/temp-netsender/config.h
@@ -1,0 +1,1 @@
+../netsender/config.h


### PR DESCRIPTION
This change adds a feature flag that prevents the offline handler from being added, as this was causing interference with the relays and LEDs on the current iteration of the PCB.