### PR TITLE
Netsender: Power-Cycle WiFi before reconfig

### DIFF
--- a/arduino/netsender/NetSender.h
+++ b/arduino/netsender/NetSender.h
@@ -33,13 +33,13 @@
 namespace NetSender {
 
 #ifdef ESP8266
-#define VERSION                192
+#define VERSION                193
 #define MAX_PINS               10
 #define DKEY_SIZE              20
 #define RESERVED_SIZE          48
 #endif
 #if defined ESP32 || defined __linux__
-#define VERSION                10022
+#define VERSION                10023
 #define MAX_PINS               20
 #define DKEY_SIZE              32
 #define RESERVED_SIZE          64

--- a/arduino/netsender/online.cpp
+++ b/arduino/netsender/online.cpp
@@ -192,7 +192,17 @@ bool wifiBegin() {
   if (ok) {
     ok = wifiConnect(Config.wifi);
     if (!ok && strcmp(Config.wifi, DEFAULT_WIFI) != 0) {
+      // The wifi cannot be reconfigured whilst it is still 
+      // trying to connect. So we turn it off, and back on.
+      ok = wifiControl(false);
+      if (!ok) {
+        return ok;
+      }
       delay(WIFI_DELAY);
+      ok = wifiControl(true);
+      if (!ok) {
+        return ok;
+      }
       ok = wifiConnect(DEFAULT_WIFI);
     }
   }


### PR DESCRIPTION
This change turns off the WiFi and turns it back on again before falling back to the default wifi SSID and password. This prevents issues where the WiFi fails to set the config which resulted in the following error:

E (85577052) wifi:sta is connecting, cannot set config

closes #91