### PR TITLE
ESP/TAS5805: Fix imports and rename consts

### DIFF
--- a/esp/speaker-netsender/components/tas5805/include/register_cmds.hpp
+++ b/esp/speaker-netsender/components/tas5805/include/register_cmds.hpp
@@ -45,8 +45,8 @@ enum class CTRL_STATE : uint8_t {
 };
 
 enum class DAMP_PBTL : uint8_t {
-    BTL_MODE  = 0b0,
-    PBTL_MODE = 0b1,
+    BTL_MODE  = 0b0 << 2,
+    PBTL_MODE = 0b1 << 2,
 };
 
 enum class ANA_GAIN : uint8_t {

--- a/esp/speaker-netsender/components/tas5805/include/tas5805.hpp
+++ b/esp/speaker-netsender/components/tas5805/include/tas5805.hpp
@@ -26,16 +26,18 @@
 
 #pragma once
 
+#include "driver/i2c_types.h"
+#include "driver/i2s_types.h"
+#include "esp_err.h"
 #include <cstdint>
-#include <stdio.h>
 #include <type_traits>
 
-constexpr auto TAS8505_CHANGE_PAGE_REG   = 0x00;
-constexpr auto TAS8505_CHANGE_BOOK_REG   = 0x7F;
-constexpr auto TAS8505_DEVICE_CTRL_1_REG = 0x02;
-constexpr auto TAS8505_DEVICE_CTRL_2_REG = 0x03;
-constexpr auto TAS8505_DIG_VOL_CTRL_REG  = 0x4C;
-constexpr auto TAS8505_AGAIN_REG         = 0x54;
+constexpr auto TAS5805_CHANGE_PAGE_REG   = 0x00;
+constexpr auto TAS5805_CHANGE_BOOK_REG   = 0x7F;
+constexpr auto TAS5805_DEVICE_CTRL_1_REG = 0x02;
+constexpr auto TAS5805_DEVICE_CTRL_2_REG = 0x03;
+constexpr auto TAS5805_DIG_VOL_CTRL_REG  = 0x4C;
+constexpr auto TAS5805_AGAIN_REG         = 0x54;
 
 /**
  * @brief TAS5805 is an I2S amplifier.

--- a/esp/speaker-netsender/components/tas5805/tas5805.cpp
+++ b/esp/speaker-netsender/components/tas5805/tas5805.cpp
@@ -28,6 +28,12 @@
 */
 
 #include "tas5805.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_log.h"
 #include "register_cmds.hpp"
 #include "driver/i2c_master.h"
 #include "driver/i2s_common.h"
@@ -39,6 +45,7 @@
 #include "hal/i2c_types.h"
 #include "portmacro.h"
 #include "sdkconfig.h"
+#include "esp_log_color.h"
 
 static const char *TAG = "tas5805";
 
@@ -75,20 +82,20 @@ TAS5805::TAS5805(i2c_master_bus_handle_t i2c_bus_handle,
     ESP_ERROR_CHECK(i2c_master_bus_add_device(bus_handle, &dev_cfg, &dev_handle));
 
     // Configure default settings for the amplifier.
-    write_reg(TAS8505_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
-    write_reg(TAS8505_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
+    write_reg(TAS5805_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
+    write_reg(TAS5805_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
 
     // Set device to Hi-Z state before configuration.
-    write_reg(TAS8505_DEVICE_CTRL_2_REG, CTRL_STATE::HI_Z);
+    write_reg(TAS5805_DEVICE_CTRL_2_REG, CTRL_STATE::HI_Z);
 
-    write_reg(TAS8505_DEVICE_CTRL_1_REG, DAMP_PBTL::PBTL_MODE); // Set PBTL MODE.
-    write_reg(TAS8505_AGAIN_REG, ANA_GAIN::DB_0); // Set Analog gain = 0dB.
+    write_reg(TAS5805_DEVICE_CTRL_1_REG, DAMP_PBTL::PBTL_MODE); // Set PBTL MODE.
+    write_reg(TAS5805_AGAIN_REG, ANA_GAIN::DB_0); // Set Analog gain = 0dB.
 
     // Set device digital volume.
     this->set_volume(DEFAULT_VOLUME);
 
     // Set back to play mode.
-    write_reg(TAS8505_DEVICE_CTRL_2_REG, CTRL_STATE::PLAY);
+    write_reg(TAS5805_DEVICE_CTRL_2_REG, CTRL_STATE::PLAY);
 
     vTaskDelay(pdMS_TO_TICKS(10));
 }
@@ -102,9 +109,9 @@ esp_err_t TAS5805::play(const char *path, volatile bool* kill_request)
     }
 
     // Put the device into play state.
-    write_reg(TAS8505_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
-    write_reg(TAS8505_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
-    write_reg(TAS8505_DEVICE_CTRL_2_REG, CTRL_STATE::PLAY);
+    write_reg(TAS5805_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
+    write_reg(TAS5805_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
+    write_reg(TAS5805_DEVICE_CTRL_2_REG, CTRL_STATE::PLAY);
 
     FILE *f = fopen(path, "rb");
     if (!f) {
@@ -204,19 +211,19 @@ esp_err_t TAS5805::play(const char *path, volatile bool* kill_request)
 
 esp_err_t TAS5805::pause()
 {
-    write_reg(TAS8505_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
-    write_reg(TAS8505_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
+    write_reg(TAS5805_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
+    write_reg(TAS5805_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
 
     // Set device to sleep.
-    write_reg(TAS8505_DEVICE_CTRL_2_REG, CTRL_STATE::SLEEP);
+    write_reg(TAS5805_DEVICE_CTRL_2_REG, CTRL_STATE::SLEEP);
 
     return ESP_OK;
 }
 
 esp_err_t TAS5805::set_volume(uint8_t vol)
 {
-    write_reg(TAS8505_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
-    write_reg(TAS8505_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
+    write_reg(TAS5805_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
+    write_reg(TAS5805_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
 
     // Bound volume.
     if (vol < 0) {
@@ -230,7 +237,7 @@ esp_err_t TAS5805::set_volume(uint8_t vol)
     uint8_t cmd = 255 - ((uint16_t)vol * 255 / 100);
 
     // Write the new volume set point.
-    write_reg(TAS8505_DIG_VOL_CTRL_REG, cmd);
+    write_reg(TAS5805_DIG_VOL_CTRL_REG, cmd);
 
     return ESP_OK;
 }


### PR DESCRIPTION
This change adds imports which were not previously required due to a specific import order previously. The change also renames some constants which had a typo in them.