### PR TITLE
ESP/Speaker: Add self check capability

### DIFF
--- a/esp/speaker-netsender/components/tas5805/include/tas5805.hpp
+++ b/esp/speaker-netsender/components/tas5805/include/tas5805.hpp
@@ -36,6 +36,7 @@ constexpr auto TAS5805_CHANGE_PAGE_REG   = 0x00;
 constexpr auto TAS5805_CHANGE_BOOK_REG   = 0x7F;
 constexpr auto TAS5805_DEVICE_CTRL_1_REG = 0x02;
 constexpr auto TAS5805_DEVICE_CTRL_2_REG = 0x03;
+constexpr auto TAS5805_CLKDET_STATUS_REG = 0x39;
 constexpr auto TAS5805_DIG_VOL_CTRL_REG  = 0x4C;
 constexpr auto TAS5805_AGAIN_REG         = 0x54;
 
@@ -51,6 +52,11 @@ public:
      * @param tx_handle i2s transmit pipe handler to play audio.
      */
     TAS5805(i2c_master_bus_handle_t handle, i2s_chan_handle_t* tx_handle);
+
+    /**
+     * @brief returns the status of the device (communicating or not).
+     */
+    bool is_connected();
 
     /**
      * @brief Reads PCM data from a file and writes it to the I2S DMA buffer.

--- a/esp/speaker-netsender/components/tas5805/tas5805.cpp
+++ b/esp/speaker-netsender/components/tas5805/tas5805.cpp
@@ -100,6 +100,29 @@ TAS5805::TAS5805(i2c_master_bus_handle_t i2c_bus_handle,
     vTaskDelay(pdMS_TO_TICKS(10));
 }
 
+bool TAS5805::is_connected()
+{
+    write_reg(TAS5805_CHANGE_PAGE_REG, PAGE::ZERO); // Go to page 0.
+    write_reg(TAS5805_CHANGE_BOOK_REG, BOOK::ZERO); // Go to book 0.
+
+    uint8_t reg = TAS5805_CLKDET_STATUS_REG;
+    uint8_t data_out = 0;
+
+    esp_err_t err = i2c_master_transmit_receive(dev_handle, &reg, 1, &data_out, 1, 50);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "I2C Read Failed: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    constexpr uint8_t PLL_LOCK = 0x08;
+    if ((data_out & PLL_LOCK) != PLL_LOCK) {
+        ESP_LOGE(TAG, "PLL not locked");
+        return false;
+    }
+
+    return true;
+}
+
 esp_err_t TAS5805::play(const char *path, volatile bool* kill_request)
 {
     // Ensure a valid I2S handle exists to send audio.

--- a/esp/speaker-netsender/main/include/self_check.hpp
+++ b/esp/speaker-netsender/main/include/self_check.hpp
@@ -1,0 +1,36 @@
+/*
+  Name:
+    self_check.hpp - Self check functions to validate hardware and
+    firmware compatibility.
+
+  Authors:
+    David Sutton <davidsutton@ausocean.org>
+
+  License:
+    Copyright (C) 2026 The Australian Ocean Lab (AusOcean).
+
+    This file is part of NetSender. NetSender is free software: you can
+    redistribute it and/or modify it under the terms of the GNU
+    General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    NetSender is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetSender in gpl.txt.  If not, see
+    <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "tas5805.hpp"
+
+/**
+ * @brief checks all peripherals and network access to validate
+ * hardware and firmware compatibility.
+ */
+bool self_check_ok(TAS5805 *amp);

--- a/esp/speaker-netsender/main/self_check.cpp
+++ b/esp/speaker-netsender/main/self_check.cpp
@@ -1,0 +1,134 @@
+/*
+  Name:
+    self_check.cpp - Self check functions to validate hardware and
+    firmware compatibility.
+
+  Authors:
+    David Sutton <davidsutton@ausocean.org>
+
+  License:
+    Copyright (C) 2026 The Australian Ocean Lab (AusOcean).
+
+    This file is part of NetSender. NetSender is free software: you can
+    redistribute it and/or modify it under the terms of the GNU
+    General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    NetSender is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetSender in gpl.txt.  If not, see
+    <http://www.gnu.org/licenses/>.
+*/
+
+#include "include/self_check.hpp"
+
+#include <stddef.h>
+#include <sys/stat.h>
+
+#include "esp_log.h"
+#include "include/globals.h"
+#include "esp_netif.h"
+#include "esp_netif_types.h"
+#include "freertos/FreeRTOS.h" // IWYU pragma: keep
+#include "freertos/projdefs.h"
+#include "esp_err.h"
+#include "esp_netif_ip_addr.h"
+#include "freertos/task.h"
+#include "tas5805.hpp"
+#include "esp_log_color.h"
+
+static constexpr auto TAG = "self_check";
+
+/**
+ * @brief Checks if Ethernet is physically connected and has a valid IP.
+ *
+ * @return true if network is ready for TCP/IP traffic, false otherwise.
+ */
+bool is_ethernet_connected()
+{
+    esp_netif_t* eth_netif = esp_netif_get_handle_from_ifkey("ETH_DEF");
+
+    if (eth_netif == NULL) {
+        ESP_LOGE(TAG, "Ethernet interface not initialized");
+        return false;
+    }
+
+    // Check physical link.
+    bool link_up = esp_netif_is_netif_up(eth_netif);
+
+    // Check for IP.
+    esp_netif_ip_info_t ip_info;
+    esp_err_t err = esp_netif_get_ip_info(eth_netif, &ip_info);
+
+    if (link_up && err == ESP_OK && ip_info.ip.addr != 0) {
+        ESP_LOGI(TAG, "Ethernet is VALID. IP: " IPSTR, IP2STR(&ip_info.ip));
+        return true;
+    }
+
+    ESP_LOGW(TAG, "Ethernet validation failed: Link=%s, IP_Assigned=%s",
+             link_up ? "UP" : "DOWN",
+             (ip_info.ip.addr != 0) ? "YES" : "NO");
+
+    return false;
+}
+
+/**
+ * @brief Checks if a filesystem on an SD card can be reached.
+ *
+ * @returns true if filesystem is accessible, false otherwise.
+ */
+bool is_sd_connected()
+{
+    struct stat st;
+    return stat(MOUNT_POINT, &st) == 0;
+}
+
+bool self_check_ok(TAS5805 *amp)
+{
+    vTaskDelay(pdMS_TO_TICKS(2000));
+
+    bool eth_ok = is_ethernet_connected();
+    bool amp_ok = amp->is_connected();
+    bool sd_ok = is_sd_connected();
+
+    bool passing = eth_ok && amp_ok && sd_ok;
+
+    ESP_LOGI(TAG, "╔══════════════════════════════════════════╗");
+    ESP_LOGI(TAG, "║           SYSTEM SELF-DIAGNOSTIC         ║");
+    ESP_LOGI(TAG, "╠══════════════════════════════════════════╣");
+
+    if (eth_ok) {
+        ESP_LOGI(TAG, "║  Ethernet Link  : [  PASS  ]             ║");
+    } else {
+        ESP_LOGE(TAG, "║  Ethernet Link  : [  FAIL  ]             ║");
+    }
+
+    if (sd_ok) {
+        ESP_LOGI(TAG, "║  SD Card Mount  : [  PASS  ]             ║");
+    } else {
+        ESP_LOGE(TAG, "║  SD Card Mount  : [  FAIL  ]             ║");
+    }
+
+    if (amp_ok) {
+        ESP_LOGI(TAG, "║  Amp Response   : [  PASS  ]             ║");
+    } else {
+        ESP_LOGE(TAG, "║  Amp Response   : [  FAIL  ]             ║");
+    }
+
+    ESP_LOGI(TAG, "╠══════════════════════════════════════════╣");
+
+    if (passing) {
+        ESP_LOGI(TAG, "║  OVERALL STATUS : [  READY ]             ║");
+        ESP_LOGI(TAG, "╚══════════════════════════════════════════╝");
+    } else {
+        ESP_LOGE(TAG, "║  OVERALL STATUS : [ ERROR  ]             ║");
+        ESP_LOGE(TAG, "╚══════════════════════════════════════════╝");
+    }
+
+    return passing;
+}


### PR DESCRIPTION
This change adds a self check function which is used to check that all devices are connected and operating as expected. This is intended to prove firmware validity, but may also be useful to diagnose hardware issues.

<img width="672" height="195" alt="image" src="https://github.com/user-attachments/assets/a230d43c-26ba-4b55-9572-2130109dd466" />
