### PR TITLE
ESP/NetSender: Update auto_gen script

### DIFF
--- a/esp/speaker-netsender/components/netsender/tools/gen_vars.py
+++ b/esp/speaker-netsender/components/netsender/tools/gen_vars.py
@@ -91,7 +91,7 @@ def generate_header(json_path: str, output_path: str) -> None:
         f.write(f'const constexpr auto ICD_VERSION = "{latest_version}";\n\n')
 
         # Export max string variable length.
-        f.write(f"const constexpr auto MAX_STR_VAR_LEN = 512;\n\n")
+        f.write("const constexpr auto MAX_STR_VAR_LEN = 512;\n\n")
 
         # Generate enums.
         f.write("enum var_type_t {\n")
@@ -178,7 +178,7 @@ def generate_header(json_path: str, output_path: str) -> None:
                 )
             elif var["type"] == VarType.INT32:
                 f.write(
-                    f'if (fprintf(fd, "%s:%ld\\n", {v_id}, state.{v_name}) < 0) {{ fclose(fd); return ESP_FAIL; }}\n'
+                    f'if (fprintf(fd, "%s:%d\\n", {v_id}, state.{v_name}) < 0) {{ fclose(fd); return ESP_FAIL; }}\n'
                 )
 
         f.write("\nfclose(fd);\n")

--- a/esp/speaker-netsender/main/include/netsender_vars.hpp
+++ b/esp/speaker-netsender/main/include/netsender_vars.hpp
@@ -61,7 +61,7 @@ inline esp_err_t write_vars_to_file(const device_var_state_t &state, const std::
         return ESP_FAIL;
     }
 
-    if (fprintf(fd, "%s:%ld\n", var::VAR_ID_VS, state.vs) < 0) {
+    if (fprintf(fd, "%s:%d\n", var::VAR_ID_VS, state.vs) < 0) {
         fclose(fd);
         return ESP_FAIL;
     }


### PR DESCRIPTION
This change fixes a print directive that prevented building with the new ESP version