### PR TITLE
(Ship) Actions: Only build release on tagged version

### DIFF
--- a/.github/workflows/esp-speaker-netsender-build.yaml
+++ b/.github/workflows/esp-speaker-netsender-build.yaml
@@ -2,8 +2,6 @@ name: Build speaker-netsender Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "speaker-netsender/v*"
 


### PR DESCRIPTION
This prevents the github action from running on all pushes to main, and only runs the action on tagged versions